### PR TITLE
Implement Mesos healthcheck

### DIFF
--- a/docs/examples/kibana-minimesos.properties
+++ b/docs/examples/kibana-minimesos.properties
@@ -9,17 +9,16 @@ spring.application.name=kibana
 mesos.framework.name=kibana
 
 # Mesos settings
-mesos.master=zk://172.17.0.3:2181/mesos
-mesos.zookeeper.server=172.17.0.3:2181
+mesos.master=zk://${mesos.zookeeper.server}/mesos
+#mesos.zookeeper.server=172.17.0.3:2181 # Usually injected.
 
 # ES location
-elasticsearch.http=http://172.17.0.2:9200
+# elasticsearch.http=http://172.17.0.2:9200 # Usually injected.
 
 # Task resources
 mesos.resources.cpus=0.5
 mesos.resources.mem=256
 mesos.resources.scale=3
-mesos.resources.ports=true
 mesos.resources.ports.UI_5061=ANY
 
 # Docker image
@@ -32,3 +31,8 @@ mesos.command=kibana --port=$UI_5061 --elasticsearch ${elasticsearch.http}
 
 # Log level
 logging.level.com.containersolutions.mesos=DEBUG
+
+# Task HealthChecks (Will kill executors that don't respond) (Note: HealthChecks do not work in Mesos 0.25.0, 0.24.0 or 0.23.0)
+# See https://issues.apache.org/jira/browse/MESOS-3738  and  https://issues.apache.org/jira/browse/MESOS-3136
+# And HTTP healthchecks still don't work: https://issues.apache.org/jira/browse/MESOS-2533
+mesos.healthCheck.command=curl localhost:$UI_5061

--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,17 @@
             <version>1.3.2.RELEASE</version>
         </dependency>
 
-        <!--<dependency>-->
-        <!--<groupId>com.github.containersolutions.mesos-starter</groupId>-->
-        <!--<artifactId>spring-boot-starter-mesos</artifactId>-->
-        <!--<version>master-SNAPSHOT</version>-->
-        <!--</dependency>-->
-
         <dependency>
-            <groupId>com.containersolutions.mesos</groupId>
+            <groupId>com.github.containersolutions.mesos-starter</groupId>
             <artifactId>spring-boot-starter-mesos</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>master-SNAPSHOT</version>
         </dependency>
+
+        <!--<dependency>-->
+        <!--<groupId>com.containersolutions.mesos</groupId>-->
+        <!--<artifactId>spring-boot-starter-mesos</artifactId>-->
+        <!--<version>1.0-SNAPSHOT</version>-->
+        <!--</dependency>-->
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.github.containersolutions.mesos-starter</groupId>
             <artifactId>spring-boot-starter-mesos</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>db5105a7e0</version>
         </dependency>
 
         <!--<dependency>-->

--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,17 @@
             <version>1.3.2.RELEASE</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.containersolutions.mesos-starter</groupId>
-            <artifactId>spring-boot-starter-mesos</artifactId>
-            <version>master-SNAPSHOT</version>
-        </dependency>
-
         <!--<dependency>-->
-        <!--<groupId>com.containersolutions.mesos</groupId>-->
+        <!--<groupId>com.github.containersolutions.mesos-starter</groupId>-->
         <!--<artifactId>spring-boot-starter-mesos</artifactId>-->
-        <!--<version>CUSTOM</version>-->
+        <!--<version>master-SNAPSHOT</version>-->
         <!--</dependency>-->
+
+        <dependency>
+            <groupId>com.containersolutions.mesos</groupId>
+            <artifactId>spring-boot-starter-mesos</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/containersolutions/mesos/HealthCheckFactory.java
+++ b/src/main/java/com/containersolutions/mesos/HealthCheckFactory.java
@@ -15,16 +15,20 @@ public class HealthCheckFactory implements MesosProtoFactory<Protos.HealthCheck>
     public Protos.HealthCheck create(List<Protos.Resource> resources) {
         // Dev note: HealthCheck does not work in 0.25: https://issues.apache.org/jira/browse/MESOS-3738
         Protos.HealthCheck healthDefault = Protos.HealthCheck.getDefaultInstance();
-        return Protos.HealthCheck.newBuilder()
-                .setCommand(
-                        Protos.CommandInfo.newBuilder()
-                                .setValue(mesosConfig.getHealthCheck().getOrDefault("command", "echo Success"))
-                )
-                .setTimeoutSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("timeout", Double.toString(healthDefault.getTimeoutSeconds()))))
-                .setDelaySeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("delay", Double.toString(healthDefault.getDelaySeconds()))))
-                .setConsecutiveFailures(Integer.valueOf(mesosConfig.getHealthCheck().getOrDefault("consecutiveFailures", Integer.toString(healthDefault.getConsecutiveFailures()))))
-                .setGracePeriodSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("gracePeriod", Double.toString(healthDefault.getGracePeriodSeconds()))))
-                .setIntervalSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("interval", Double.toString(healthDefault.getIntervalSeconds()))))
-                .build();
+        if (mesosConfig.getHealthCheck() == null) {
+            return healthDefault;
+        } else {
+            return Protos.HealthCheck.newBuilder()
+                    .setCommand(
+                            Protos.CommandInfo.newBuilder()
+                                    .setValue(mesosConfig.getHealthCheck().getOrDefault("command", "echo Success"))
+                    )
+                    .setTimeoutSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("timeout", Double.toString(healthDefault.getTimeoutSeconds()))))
+                    .setDelaySeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("delay", Double.toString(healthDefault.getDelaySeconds()))))
+                    .setConsecutiveFailures(Integer.valueOf(mesosConfig.getHealthCheck().getOrDefault("consecutiveFailures", Integer.toString(healthDefault.getConsecutiveFailures()))))
+                    .setGracePeriodSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("gracePeriod", Double.toString(healthDefault.getGracePeriodSeconds()))))
+                    .setIntervalSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("interval", Double.toString(healthDefault.getIntervalSeconds()))))
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/containersolutions/mesos/HealthCheckFactory.java
+++ b/src/main/java/com/containersolutions/mesos/HealthCheckFactory.java
@@ -1,0 +1,30 @@
+package com.containersolutions.mesos;
+
+import com.containersolutions.mesos.scheduler.MesosProtoFactory;
+import com.containersolutions.mesos.scheduler.config.FrameworkMesosConfigProperties;
+import org.apache.mesos.Protos;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+public class HealthCheckFactory implements MesosProtoFactory<Protos.HealthCheck> {
+    @Autowired
+    FrameworkMesosConfigProperties mesosConfig;
+
+    @Override
+    public Protos.HealthCheck create(List<Protos.Resource> resources) {
+        // Dev note: HealthCheck does not work in 0.25: https://issues.apache.org/jira/browse/MESOS-3738
+        Protos.HealthCheck healthDefault = Protos.HealthCheck.getDefaultInstance();
+        return Protos.HealthCheck.newBuilder()
+                .setCommand(
+                        Protos.CommandInfo.newBuilder()
+                                .setValue(mesosConfig.getHealthCheck().getOrDefault("command", "echo Success"))
+                )
+                .setTimeoutSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("timeout", Double.toString(healthDefault.getTimeoutSeconds()))))
+                .setDelaySeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("delay", Double.toString(healthDefault.getDelaySeconds()))))
+                .setConsecutiveFailures(Integer.valueOf(mesosConfig.getHealthCheck().getOrDefault("consecutiveFailures", Integer.toString(healthDefault.getConsecutiveFailures()))))
+                .setGracePeriodSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("gracePeriod", Double.toString(healthDefault.getGracePeriodSeconds()))))
+                .setIntervalSeconds(Double.valueOf(mesosConfig.getHealthCheck().getOrDefault("interval", Double.toString(healthDefault.getIntervalSeconds()))))
+                .build();
+    }
+}

--- a/src/main/java/com/containersolutions/mesos/HealthCheckFactory.java
+++ b/src/main/java/com/containersolutions/mesos/HealthCheckFactory.java
@@ -5,14 +5,12 @@ import com.containersolutions.mesos.scheduler.config.FrameworkMesosConfigPropert
 import org.apache.mesos.Protos;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.List;
-
 public class HealthCheckFactory implements MesosProtoFactory<Protos.HealthCheck> {
     @Autowired
     FrameworkMesosConfigProperties mesosConfig;
 
     @Override
-    public Protos.HealthCheck create(List<Protos.Resource> resources) {
+    public Protos.HealthCheck create() {
         // Dev note: HealthCheck does not work in 0.25: https://issues.apache.org/jira/browse/MESOS-3738
         Protos.HealthCheck healthDefault = Protos.HealthCheck.getDefaultInstance();
         if (mesosConfig.getHealthCheck() == null) {

--- a/src/main/java/com/containersolutions/mesos/MesosFramework.java
+++ b/src/main/java/com/containersolutions/mesos/MesosFramework.java
@@ -1,4 +1,4 @@
-package com.containersolutions.mesosframework;
+package com.containersolutions.mesos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/containersolutions/mesos/config/autoconfigure/FrameworkSchedulerConfiguration.java
+++ b/src/main/java/com/containersolutions/mesos/config/autoconfigure/FrameworkSchedulerConfiguration.java
@@ -52,7 +52,7 @@ public class FrameworkSchedulerConfiguration {
             Protos.TaskInfo taskInfo = taskInfoFactoryDocker.create(taskId, offer, resources);
             Protos.TaskInfo built = Protos.TaskInfo.newBuilder()
                     .mergeFrom(taskInfo)
-                    .setHealthCheck(healthCheckFactory.create(resources))
+                    .setHealthCheck(healthCheckFactory.create())
                     .build();
             logger.debug(built);
             return built;
@@ -67,7 +67,7 @@ public class FrameworkSchedulerConfiguration {
             Protos.TaskInfo taskInfo = taskInfoFactoryCommand.create(taskId, offer, resources);
             Protos.TaskInfo built = Protos.TaskInfo.newBuilder()
                     .mergeFrom(taskInfo)
-                    .setHealthCheck(healthCheckFactory.create(resources))
+                    .setHealthCheck(healthCheckFactory.create())
                     .build();
             logger.debug(built);
             return built;

--- a/src/main/java/com/containersolutions/mesos/config/autoconfigure/FrameworkSchedulerConfiguration.java
+++ b/src/main/java/com/containersolutions/mesos/config/autoconfigure/FrameworkSchedulerConfiguration.java
@@ -1,0 +1,76 @@
+package com.containersolutions.mesos.config.autoconfigure;
+
+import com.containersolutions.mesos.HealthCheckFactory;
+import com.containersolutions.mesos.scheduler.TaskInfoFactory;
+import com.containersolutions.mesos.scheduler.TaskInfoFactoryCommand;
+import com.containersolutions.mesos.scheduler.TaskInfoFactoryDocker;
+import com.containersolutions.mesos.scheduler.config.FrameworkMesosConfigProperties;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.Protos;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@Import({MesosSchedulerConfiguration.class})
+public class FrameworkSchedulerConfiguration {
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    @Bean
+    @ConditionalOnMissingBean(HealthCheckFactory.class)
+    public HealthCheckFactory healthCheckFactory() {
+        return new HealthCheckFactory();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(FrameworkMesosConfigProperties.class)
+    public FrameworkMesosConfigProperties frameworkMesosConfigProperties() {
+        return new FrameworkMesosConfigProperties();
+    }
+
+    @Bean(name = "defaultTaskInfoFactoryDocker")
+    public TaskInfoFactoryDocker defaulTaskInfoFactoryDocker() {
+        return new TaskInfoFactoryDocker();
+    }
+
+    @Bean(name = "defaultTaskInfoFactoryCommand")
+    public TaskInfoFactoryCommand defaultTaskInfoFactoryCommand() {
+        return new TaskInfoFactoryCommand();
+    }
+
+    // Overridden TaskInfoFactoryBean
+    @Bean(name = "frameworkTaskInfoFactoryDocker")
+    @ConditionalOnProperty(prefix = "mesos.docker", name = {"image"})
+    @Primary
+    public TaskInfoFactory taskInfoFactoryDocker(@Qualifier("defaultTaskInfoFactoryDocker") TaskInfoFactoryDocker taskInfoFactoryDocker, HealthCheckFactory healthCheckFactory) {
+        return (taskId, offer, resources) -> {
+            Protos.TaskInfo taskInfo = taskInfoFactoryDocker.create(taskId, offer, resources);
+            Protos.TaskInfo built = Protos.TaskInfo.newBuilder()
+                    .mergeFrom(taskInfo)
+                    .setHealthCheck(healthCheckFactory.create(resources))
+                    .build();
+            logger.debug(built);
+            return built;
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "frameworkTaskInfoFactoryDocker")
+    @Primary
+    public TaskInfoFactory taskInfoFactoryCommand(@Qualifier("defaultTaskInfoFactoryCommand") TaskInfoFactoryCommand taskInfoFactoryCommand, HealthCheckFactory healthCheckFactory) {
+        return (taskId, offer, resources) -> {
+            Protos.TaskInfo taskInfo = taskInfoFactoryCommand.create(taskId, offer, resources);
+            Protos.TaskInfo built = Protos.TaskInfo.newBuilder()
+                    .mergeFrom(taskInfo)
+                    .setHealthCheck(healthCheckFactory.create(resources))
+                    .build();
+            logger.debug(built);
+            return built;
+        };
+    }
+}

--- a/src/main/java/com/containersolutions/mesos/config/autoconfigure/TaskActuatorConfiguration.java
+++ b/src/main/java/com/containersolutions/mesos/config/autoconfigure/TaskActuatorConfiguration.java
@@ -1,6 +1,5 @@
-package com.containersolutions.mesosframework.config.autoconfigure;
+package com.containersolutions.mesos.config.autoconfigure;
 
-import com.containersolutions.mesos.config.autoconfigure.MesosSchedulerConfiguration;
 import com.containersolutions.mesos.scheduler.events.StatusUpdateEvent;
 import com.containersolutions.mesos.scheduler.state.StateRepository;
 import org.apache.mesos.Protos;
@@ -9,9 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,9 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Configuration
-@ConditionalOnClass(HealthIndicator.class)
-@AutoConfigureBefore({org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration.class})
-@AutoConfigureAfter({MesosSchedulerConfiguration.class})
 public class TaskActuatorConfiguration implements ApplicationListener<StatusUpdateEvent> {
     @Autowired
     StateRepository stateRepository;
@@ -51,7 +44,6 @@ public class TaskActuatorConfiguration implements ApplicationListener<StatusUpda
                     Map<String, Protos.TaskStatus> state = getTasksForState(taskState);
                     builder.withDetail(taskState.name(), state.size());
                 }
-
             }
         };
     }

--- a/src/main/java/com/containersolutions/mesos/scheduler/config/FrameworkMesosConfigProperties.java
+++ b/src/main/java/com/containersolutions/mesos/scheduler/config/FrameworkMesosConfigProperties.java
@@ -1,0 +1,18 @@
+package com.containersolutions.mesos.scheduler.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "mesos")
+public class FrameworkMesosConfigProperties extends MesosConfigProperties {
+    private Map<String, String> healthCheck;
+
+    public Map<String, String> getHealthCheck() {
+        return healthCheck;
+    }
+
+    public void setHealthCheck(Map<String, String> healthCheck) {
+        this.healthCheck = healthCheck;
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.containersolutions.mesosframework.config.autoconfigure.TaskActuatorConfiguration
+com.containersolutions.mesos.config.autoconfigure.TaskActuatorConfiguration

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.containersolutions.mesos.config.autoconfigure.TaskActuatorConfiguration


### PR DESCRIPTION
Task HealthChecks (Will kill executors that don't respond) (Note: HealthChecks do not work in Mesos 0.25.0, 0.24.0 or 0.23.0)
See https://issues.apache.org/jira/browse/MESOS-3738  and  https://issues.apache.org/jira/browse/MESOS-3136
And HTTP healthchecks still don't work: https://issues.apache.org/jira/browse/MESOS-2533
